### PR TITLE
fix: call .join on stdin chunks array using empty string separator

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -12,7 +12,7 @@ process.stdin.on('data', function (chunk) {
 })
 
 process.stdin.on('end', function () {
-  const input = JSON.parse(chunks.join())
+  const input = JSON.parse(chunks.join(''))
   const request = shared.deserializeRequest(fetch, ...input)
 
   fetch(request)


### PR DESCRIPTION
The correct way to specify no separator is to use the empty string.
See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join.
Issue addressed: https://github.com/larsgw/sync-fetch/issues/6

I didn't write a test case as this is a clear bug and the likelihood of regression would seem to be low, but I can write one if that would be desirable.