### PR TITLE
Replace 'buffer' dependency with native TextEncoder

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 
-const { Buffer } = require('buffer/')
+const textEncoder = new TextEncoder();
 
 function syncFetch (...args) {
   const request = new syncFetch.Request(...args)
@@ -102,7 +102,7 @@ class SyncRequest {
     this[INTERNALS] = {
       method: init.method || 'GET',
       headers: new syncFetch.Headers(init.headers),
-      body: init.body ? Buffer.from(init.body) : null,
+      body: init.body ? textEncoder.encode(init.body) : null,
       credentials: init.credentials || 'omit',
 
       // Non-spec
@@ -187,7 +187,7 @@ class SyncRequest {
 class SyncResponse {
   constructor (body, init = {}) {
     this[INTERNALS] = {
-      body: body ? Buffer.from(body) : null,
+      body: body ? textEncoder.encode(body) : null,
       bodyUsed: false,
 
       headers: new syncFetch.Headers(init.headers),
@@ -244,7 +244,7 @@ class SyncResponse {
 class Body {
   constructor (body) {
     this[INTERNALS] = {
-      body: Buffer.from(body),
+      body: textEncoder.encode(body),
       bodyUsed: false
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "buffer": "^5.7.1",
         "node-fetch": "^2.6.1"
       },
       "devDependencies": {
@@ -532,7 +531,8 @@
     "node_modules/base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -812,29 +812,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "dev": true
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
     },
     "node_modules/buffer-from": {
       "version": "1.1.1",
@@ -3139,6 +3116,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6733,7 +6711,8 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -6985,15 +6964,6 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -8775,7 +8745,8 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/larsgw/sync-fetch#readme",
   "dependencies": {
-    "buffer": "^5.7.1",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!
Thanks for this great package! I love using it.
I realized sync-fetch's browser version uses a library called `buffer` to convert strings to `Uint8Array`. I think it can basically use `TextEncoder` which is available in the browsers.
This would reduce the bundle size as well :)
